### PR TITLE
Create `linear_automorphisms` and `is_linearly_self_equivalent` functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ build/
 /sboxU/sboxU_cython/cpp_utils.cpp
 /sboxU/sboxU_cython/cpp_diff_lin_no_fp_lat.cpp
 /sboxU/sboxU_cython/cpp_equiv_approx.cpp
+/sboxU/sboxU_cython/cpp_partition_preserving_linear_mapping.cpp
 # ignore automatically generated files
 *~

--- a/sboxU/__init__.py
+++ b/sboxU/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# Modified on 2025-07-23 by baudrin-j.
 
 from .sboxU_cython import *
 from .utils import *
@@ -10,6 +11,7 @@ from .cycles import *
 from .quadratic import *
 from .analysis import *
 from .known_functions import *
+from .linear_automorphisms import *
 
 from .fp_extension import *
 

--- a/sboxU/linear_automorphisms.py
+++ b/sboxU/linear_automorphisms.py
@@ -1,0 +1,170 @@
+# Created on 2025-07-06 by baudrin-j.
+# Modified on 2025-07-30 by baudrin-j.
+
+from .sboxU_cython import *
+from .utils import *
+from .linear import *
+from .ccz import table_linear_automorphisms
+from time import time
+
+# TODO add a test to compare with the linear automorphisms obtained from code equivalence.
+
+
+def linear_automorphisms(lut, algorithm="alt_partition_diag_mappings", number_of_threads=8):
+    """Return the linear automorphisms of a function F,
+    i.e. all pairs of linear bijections (A, B) satisfying B o F o A = F.
+
+    If the LAT is already computed and stored, the function linear_automorphisms_from_lat behaves the same
+    but avoid the unnecessary recomputation of the LAT.
+
+    More information on the search algorithms can be found in the corresponding C++ code.
+
+    Args:
+        lut: The look-up table of F.
+        algorithm (str): A string describing the search algorithm to use. algorithm must be chosen among:
+                    - "alt_partition_diag_mappings" (default)
+                    - "alt_partition"
+                    - "std_partition_diag_mappings"
+        number_of_threads (int): The number of threads to use. By default, it is set to 8.
+
+    Returns:
+        list: A list of pairs of look-up tables corresponding to all pairs of linear bijections (A, B) satisfying B o F o A = F.
+
+    """
+    return linear_automorphisms_from_lat(lat(lut), algorithm, number_of_threads)
+
+
+def is_linearly_self_equivalent(lut, algorithm="alt_partition_diag_mappings", number_of_threads=8):
+    """ Checks whether a function F is linearly self-equivalent, i.e,
+     if it exists a non-trivial pair of linear bijections (A, B) satisfying B o F o A = F.
+
+     If the LAT is already computed and stored, the function is_linearly_self_equivalent_from_lat behaves the same
+    but avoid the unnecessary recomputation of the LAT.
+
+    More information on the search algorithms can be found in the corresponding C++ code.
+
+    Args:
+        lut: The look-up table of F.
+        algorithm (str): A string describing the search algorithm to use. algorithm must be chosen among:
+                    - "alt_partition_diag_mappings" (default)
+                    - "alt_partition"
+                    - "std_partition_diag_mappings"
+        number_of_threads (int): The number of threads to use. By default, it is set to 8.
+
+    Returns:
+        tuple: A pair of look-up tables corresponding to a non-trivial (A, B) satisfying B o F o A = F, *if it exists*.
+        Return False otherwise.
+
+    """
+    return is_linearly_self_equivalent_from_lat(lat(lut), algorithm, number_of_threads)
+
+
+def test_linear_automorphisms(lut, algorithms=None, number_of_threads=8):
+    """ Test function for linear_automorphisms.
+    Verifies that each result coincide for all algorithms and that the returned pairs indeed correspond to linear automorphisms.
+
+    Tested for all algorithms, for number_of_threads= 1 and 8 on the ortho-derivatives of all quadratics functions from:
+        - sboxU.known_functions.sixBitAPN
+        - sboxU.known_functions.sevenBitAPN
+        - some of the ones of sboxU.known_functions.eightBitAPN.
+
+    Args:
+        lut: The look-up table of F.
+        algorithms (list): A list of strings describing the search algorithms to use. algorithm must be chosen among:
+                    - "alt_partition_diag_mappings" (default)
+                    - "alt_partition"
+                    - "std_partition_diag_mappings"
+                    - "sage"
+        number_of_threads (int): The number of threads to use. By default, it is set to 8.
+    """
+    tab = lat(lut)
+    automorphisms_algo_by_algo = []
+
+    algo_sage = False
+    if algorithms is None:
+        algorithms = ["alt_partition_diag_mappings", "alt_partition", "std_partition_diag_mappings"]
+        algo_sage = True
+    else:
+        if "sage" in algorithms:
+            algo_sage = True
+            algorithms.remove("sage")
+
+    print(algorithms, end='')
+    if algo_sage:
+        print("sage")
+    else:
+        print()
+
+    print('Search time ', end='')
+    # The C++ searches
+    for algo in algorithms:
+        start = time()
+        automorphisms = linear_automorphisms_from_lat(tab, algo, number_of_threads)
+        stop = time()
+        automorphisms = set([tuple([tuple(a), tuple(b)]) for a, b in automorphisms])
+        automorphisms_algo_by_algo.append(automorphisms)
+        print("%.3f " % (stop - start), end='')
+
+    # The sage search
+    if algo_sage:
+        start = time()
+        automorphisms = table_linear_automorphisms(tab)
+        stop = time()
+        automorphisms = set([tuple([tuple(a), tuple(b)]) for a, b in automorphisms])
+        automorphisms_algo_by_algo.append(automorphisms)
+        print("%.3f " % (stop - start), end='')
+
+    print()
+
+    print('Asserts time', end='')
+    start = time()
+    # All algorithms return the same output
+    assert all([automorphisms == automorphisms_algo_by_algo[0] for automorphisms in automorphisms_algo_by_algo])
+    # Each output is indeed an automorphism
+    for a, b in automorphisms_algo_by_algo[0]:
+        a = linear_function_lut_to_matrix(a).transpose().inverse()
+        a = linear_function_matrix_to_lut(a)
+        b = linear_function_lut_to_matrix(b).transpose()
+        b = linear_function_matrix_to_lut(b)
+        assert comp([b, lut, a]) == lut
+    stop = time()
+    print(" %.3f " % (stop - start))
+
+
+def test_is_linearly_self_equivalent(lut, number_of_threads=8):
+    """ Test function for is_linearly_self_equivalent.
+    Verifies that the result provided by the C++ searches are in line with the sage search.
+
+    Tested for all algorithms, for number_of_threads= 1 and 8 on the ortho-derivatives of all quadratics functions from:
+        - sboxU.known_functions.sixBitAPN
+        - sboxU.known_functions.sevenBitAPN
+        - some of the ones of sboxU.known_functions.eightBitAPN
+
+    Args:
+        lut: The look-up table of F.
+        number_of_threads (int): The number of threads to use. By default, it is set to 8.
+    """
+    tab = lat(lut)
+    automorphism_algo_by_algo = []
+    print("[alt_partition_diag_mappings, alt_partition, std_partition_diag_mappings, sage]")
+
+    # The C++ searches
+    for algo in ["alt_partition_diag_mappings", "alt_partition", "std_partition_diag_mappings"]:
+        start = time()
+        automorphism = is_linearly_self_equivalent_from_lat(tab, algo, number_of_threads)
+        stop = time()
+        automorphism_algo_by_algo.append(automorphism)
+        print("%.3f " % (stop - start), end='')
+
+    # The sage search
+    start = time()
+    automorphism_sage = table_linear_automorphisms(tab)
+    stop = time()
+    automorphism_sage = set([tuple([tuple(a), tuple(b)]) for a, b in automorphism_sage])
+    print("%.3f " % (stop - start), end='')
+
+    if len(automorphism_sage) == 1:
+        assert all([automorphism is False for automorphism in automorphism_algo_by_algo])
+    else:
+        assert all([automorphism[0] or automorphism[1] for automorphism in automorphism_algo_by_algo])
+    print()

--- a/sboxU/sboxU_cython/__init__.py
+++ b/sboxU/sboxU_cython/__init__.py
@@ -1,6 +1,9 @@
 # Time-stamp: <2021-08-12 16:45:37 lperrin>
+# Modified on 2025-07-06 by baudrin-j
+
 from .cpp_diff_lin import *
 from .cpp_utils import *
 from .cpp_equiv import *
 from .cpp_equiv_approx import *
 from .cpp_ccz import *
+from .cpp_partition_preserving_linear_mapping import *

--- a/sboxU/sboxU_cython/cpp_partition_preserving_linear_mapping.pyx
+++ b/sboxU/sboxU_cython/cpp_partition_preserving_linear_mapping.pyx
@@ -1,0 +1,50 @@
+# Created by Jules Baudrin on 06/07/2025
+# Modified by Jules Baudrin on 30/07/2025
+
+import os
+from .sboxu_cpp cimport *
+
+def is_linearly_self_equivalent_from_lat(lat, algorithm="alt_partition_diag_mappings", number_of_threads=8):
+    """ Checks whether a function F is linearly self-equivalent (*) from its linear approximation table (LAT).
+     (*) i.e. if it exists a non-trivial pair of linear bijections (A, B) satisfying B o F o A = F.
+
+    More information on the search algorithms can be found in the corresponding C++ code.
+
+    Args:
+        lat: The linear approximation table of F.
+        algorithm (str): A string describing the search algorithm to use. algorithm must be chosen among:
+                    - "alt_partition_diag_mappings" (default)
+                    - "alt_partition"
+                    - "std_partition_diag_mappings"
+        number_of_threads (int): The number of threads to use. By default, it is set to 8.
+
+    Returns:
+        A pair of look-up tables corresponding to a non-trivial (A, B) satisfying B o F o A = F, *if it exists*.
+        Return False otherwise.
+
+    """
+    res = cpp_is_linearly_self_equivalent_from_lat(lat, algorithm.encode('ascii'), number_of_threads)
+    if res == ([], []):
+        return False
+    else:
+        return res
+
+def linear_automorphisms_from_lat(lat, algorithm="alt_partition_diag_mappings", number_of_threads=8):
+    """ Compute the linear automorphisms (*) of a function F from its linear approximation table (LAT).
+        (*) i.e. all pairs of linear bijections (A, B) satisfying B o F o A = F.
+
+        More information on the search algorithms can be found in the corresponding C++ code.
+
+        Args:
+            lat: The linear approximation table of F.
+            algorithm (str): A string describing the search algorithm to use. algorithm must be chosen among:
+                        - "alt_partition_diag_mappings" (default)
+                        - "alt_partition"
+                        - "std_partition_diag_mappings"
+            number_of_threads (int): The number of threads to use. By default, it is set to 8.
+
+        Returns:
+            list: A list of pairs of look-up tables corresponding to all pairs of linear bijections (A, B) satisfying B o F o A = F.
+
+    """
+    return cpp_linear_automorphisms_from_lat(lat, algorithm.encode('ascii'), number_of_threads)

--- a/sboxU/sboxU_cython/sboxu_cpp.hpp
+++ b/sboxU/sboxU_cython/sboxu_cpp.hpp
@@ -36,6 +36,8 @@ typedef int64_t Integer;
 typedef uint64_t BinWord;
 typedef std::vector<BinWord> Sbox;
 typedef std::pair<uint64_t, uint64_t> IOpair;
+#define EMPTY UINT64_MAX
+#define ONE ((BinWord) 1)
 
 
 // !SECTION! Including sub-modules

--- a/sboxU/sboxU_cython/sboxu_cpp.pxd
+++ b/sboxU/sboxU_cython/sboxu_cpp.pxd
@@ -1,11 +1,13 @@
 # -*-python-*- 
 # Time-stamp: <2024-04-26 10:26:12 leo>
+# Modified on 2025-07-30 by baudrin-j
 
 from libcpp cimport bool
 from libcpp.vector cimport vector
 from libcpp.map cimport map
 from libcpp.string cimport string
 from libc.stdint cimport int64_t, uint64_t
+from libcpp.utility cimport pair
 
 cdef extern from "sboxu_cpp_utils.cpp":
     pass
@@ -92,3 +94,10 @@ cdef extern from "sboxu_cpp_fp_lat.hpp":
     cdef vector[ double ] fpt_lat_row(const vector[int] s, const int p, const int m, const int a)
     cdef double fpt_max_lat(const vector[int] s, const int p, const int m, const int num_threads)
     cdef map[double, int] fpt_walsh_spectrum(const vector[int] s, const int p, const int m, const double epsilon, const int num_threads)        
+
+cdef extern from "sboxu_cpp_partition_preserving_linear_mapping.cpp" :
+    pass
+
+cdef extern from "sboxu_cpp_partition_preserving_linear_mapping.hpp":
+    cdef pair[vector[uint64_t], vector[uint64_t]] cpp_is_linearly_self_equivalent_from_lat(const vector[vector[int64_t]] lat, const string algo, const unsigned int number_of_threads)
+    cdef vector[pair[vector[uint64_t], vector[uint64_t]]] cpp_linear_automorphisms_from_lat(const vector[vector[int64_t]] lat, const string algo, const unsigned int number_of_threads)

--- a/sboxU/sboxU_cython/sboxu_cpp_partition_preserving_linear_mapping.cpp
+++ b/sboxU/sboxU_cython/sboxu_cpp_partition_preserving_linear_mapping.cpp
@@ -1,0 +1,78 @@
+//
+// Created on 2025-06-19 by baudrin-j.
+// Modified on 2025-07-27 by baudrin-j.
+//
+#include "sboxu_cpp_partition_preserving_linear_mapping.hpp"
+
+// The core search function
+//  1) single_non_trivial_answer
+//      - if true, the search is stopped whenever non-trivial automorphism is found (if found).
+//		- otherwise, a full search is performed.
+//  2) diagonal_mappings
+//      - if true, the automorphisms are built under the form diag(A, B). Can be used both alternative_partition=true or false.
+//      - otherwise, generic 2n-bit-mappings are searched. The combination (diagonal_mappings = false, alternative_partition=true) still
+//        returns automorphisms of the form diag(A, B). In that case, the constraint comes from the partition.
+//	3) alternative_partition
+//      - if true, the standard partition is used : {lat[x][y], x, y \in GF(2**n)} is split by values.
+//      - otherwise, {lat[x][y], x, y \in GF(2**n)} is split by values. Furthermore, the buckets are split
+//        so that (x, 0) is necessarily mapped onto (x', 0) (and the same for (0, y) -> (0, y') ).
+vector<pair<vector<BinWord>, vector<BinWord>>> linear_automorphism_search(const vector<vector<Integer>> &lat, const bool &single_non_trivial_answer, const bool &diagonal_mappings, const bool &alternative_partition, const unsigned int &number_of_threads) {
+	Integer n = log2(lat.size());
+	BinWord size = (ONE << n);
+
+	map <pair<Integer, string>, vector<BinWord>> dict;
+	for(BinWord x = 0; x < size; x++) {
+		for(BinWord y = 0; y < size; y++) {
+			if(!alternative_partition || (x != 0 && y != 0)) // if !alternative_partition, only take into account the value lat[x][y] ('mixed' is appended for all x, y)
+				dict[{lat[x][y], "mixed"}].push_back((y << n) ^ x);
+			else if(x == 0) // Otherwise, split the buckets so that (x, 0) is necessarily mapped onto (x', 0) (and the same for (0, y) -> (0, y') ).
+				dict[{lat[x][y], "y only"}].push_back((y << n) ^ x);
+			else // y == 0
+				dict[{lat[x][y], "x only"}].push_back((y << n) ^ x);
+		}
+	}
+	Partition<pair<Integer, string>> partition(dict, 2 * n, diagonal_mappings);
+	PartitionPreservingLinearMappings<pair<Integer, string>> pplm(&partition, &partition, single_non_trivial_answer, diagonal_mappings, number_of_threads);
+	pplm.search();
+
+	vector<pair<vector<BinWord>, vector<BinWord>>> splitted_luts;
+	for(const auto &lut: pplm.found_mappings) {
+		vector<BinWord> lutA, lutB;
+		for(uint i = 0; i < (ONE << n); i++) {
+			lutA.push_back(lut[i]);
+			if(diagonal_mappings) // If diagonal_mappings, lut contains the concatenation of lutA and lutB
+				lutB.push_back(lut[(ONE << n) + i]);
+			else // Otherwise, lutA and lutB must be extracted from the lut of diag(A, B)
+				lutB.push_back(lut[i << n] >> n);
+		}
+		splitted_luts.push_back({lutA, lutB});
+	}
+	return splitted_luts;
+}
+
+// The three different search strategies
+vector<pair<vector<BinWord>,vector<BinWord>>> linear_automorphisms(const vector<vector<Integer>> &lat, const bool &single_non_trivial_answer, const string &algo, const unsigned int &number_of_threads) {
+	vector<pair<vector<BinWord>, vector<BinWord>>> luts;
+	if(algo == "alt_partition_diag_mappings")
+		luts = linear_automorphism_search(lat, single_non_trivial_answer, true, true, number_of_threads);
+	else if(algo == "alt_partition")
+		luts = linear_automorphism_search(lat, single_non_trivial_answer, false,true, number_of_threads);
+	else if(algo == "std_partition_diag_mappings")
+		luts = linear_automorphism_search(lat, single_non_trivial_answer, true, false, number_of_threads);
+
+	return luts;
+}
+
+// The full search
+vector<pair<vector<BinWord>, vector<BinWord>>> cpp_linear_automorphisms_from_lat(const vector<vector<Integer>> &lat, const string algo, const unsigned int &number_of_threads) {
+	return linear_automorphisms(lat, false, algo, number_of_threads);
+}
+
+// The early-abort search
+pair<vector<BinWord>, vector<BinWord>> cpp_is_linearly_self_equivalent_from_lat(const vector<vector<Integer>> &lat, const string algo, const unsigned int &number_of_threads) {
+	auto luts = linear_automorphisms(lat, true, algo, number_of_threads);
+	if(luts.size())
+		return luts[0];
+	else
+		return {{}, {}};
+}

--- a/sboxU/sboxU_cython/sboxu_cpp_partition_preserving_linear_mapping.hpp
+++ b/sboxU/sboxU_cython/sboxu_cpp_partition_preserving_linear_mapping.hpp
@@ -1,0 +1,360 @@
+// Created on 2025-06-19 by baudrin-j.
+// Modified on 2025-07-27 by baudrin-j.
+
+#ifndef PARTITION_PRESERVING_LINEAR_MAPPING_HPP
+#define PARTITION_PRESERVING_LINEAR_MAPPING_HPP
+
+#include <iostream>
+#include <omp.h>
+
+#include <cmath>
+#include <algorithm>
+#include <vector>
+#include <map>
+#include <set>
+#include <cassert>
+#include <stdexcept>
+
+#include "sboxu_cpp_utils.hpp"
+
+#define BINWORD_SIZE 64
+
+using namespace std;
+
+/*
+ * =======================
+ * The Partition class
+ * =======================
+ * It describes a partition of GF(2)^n. It is made of :
+ * - a dictionary whose key can be anything and whose value is a subset of GF(2)^n (represented as a vector of BinWord).
+ *      The subsets form a partition of GF(2)^n.
+ * - a "reverse dictionary" which maps any value of GF(2)^n to the corresponding key.
+ * - an int corresponding to the dimension of GF(2)^n, i.e equal to n.
+ * - a basis of GF(2)^n. (or of GF(2)^(n/2) in some cases).
+ * - (in some cases another basis of GF(2)^(n/2))
+ *
+ * Some methods are also described:
+ * - in_which_bucket returns the key corresponding to the only bucket in which the parameter belongs to
+ * - adapted_basis (and diagonal_adapted_basis) selects a basis of GF(2**n) (two bases of GF(2**(n/2))) suited to the search for (diagonal) partition-preserving linear mappings.
+ */
+template <class keyType>
+class Partition {
+private:
+	uint64_t dimension; // Dimension of the space.
+	map<keyType, vector<BinWord>> partition; // A partition of the space according to some key type.
+	map<BinWord, keyType> reverse_dict; // The reverse dictionary.
+public:
+
+	vector<BinWord> basis; // A basis of the space.
+	vector<BinWord> basis_B; // only used in case of diagonal mappings
+
+	Partition(map<keyType, vector<BinWord>> _partition, Integer _dimension, bool diagonal_mappings) : dimension(_dimension), partition(_partition)
+	{
+		set<BinWord> all_values;
+		for(const auto &[k, v]: partition) {
+			Integer previous_size = all_values.size();
+			all_values.insert(v.begin(), v.end());
+			assert(previous_size + v.size() == all_values.size()); // All sets must be disjoint.
+			for(const auto &x: v) {
+				assert(x < (ONE << dimension)); // Each element belongs to [0, 2^n-1]
+				reverse_dict[x] = k;
+			}
+		}
+		assert(all_values.size() == ONE << dimension); // all_values = [0, 2^n-1]
+		if(diagonal_mappings)
+			diagonal_adapted_basis();
+		else
+			adapted_basis();
+	};
+
+	uint64_t dim() {return dimension;}
+
+	// Return the key corresponding to the only bucket to which elt belongs
+	keyType in_which_bucket(const BinWord &elt) {
+		return reverse_dict[elt];
+	}
+
+	// Return a sorted list of pair (length, key) which corresponds to the ordering of the partition {k:v} by increasing length of its values (v).
+	vector<pair<int, keyType>> _increasing_order() {
+		vector<pair<int, keyType>> size_key_table;
+
+		for (const auto &v : partition)
+			size_key_table.push_back({v.second.size(), v.first}); // (size, key) pair
+		sort(size_key_table.begin(), size_key_table.end());
+
+		return size_key_table;
+	}
+
+	// Select a better basis which minimizes the number of choices when looking for partition-preserving linear mappings.
+	void adapted_basis() {
+		basis.clear();
+		// Enumerate the partition {k : v} by increasing length of v
+		for(const auto &[len, key]: _increasing_order()) {
+			if(basis.size() == dimension)
+				break;
+			// Enumerate all elements of v
+			for(const auto &x: partition[key]) {
+				// Add x to the basis only if the rank increases
+				basis.push_back(x);
+				if(rank_of_vector_set_cpp(basis) != (Integer)basis.size())
+					basis.pop_back();
+			}
+		}
+	}
+
+	// Select an *independent family of size n/2* which minimizes the number of choices when looking for partition-preserving linear mappings that are DIAGONAL.
+	// The family {f_i} has the property that Span(f_i >> n/2, 0 <= i <= dim/2) = GF(2**n/2)  and Span((f_i << n/2) >> n/2, 0 <= i <= dim/2)= GF(2**n/2).
+	void diagonal_adapted_basis() {
+		assert(dimension % 2 == 0);
+		uint64_t half_dim = dimension / 2;
+
+		basis.clear(); // A basis of GF(2**(n/2))
+		basis_B.clear(); // Another basis of GF(2**(n/2))
+		// Enumerate the partition {k : v} by increasing length of v
+		for(const auto &[len, key]: _increasing_order()) {
+			if(basis.size() == half_dim)
+				break;
+			// Enumerate all elements of v
+			for(const auto &x: partition[key]) {
+				// Add x to the basis only if the rank increases
+				basis.push_back((x << (BINWORD_SIZE - half_dim)) >> (BINWORD_SIZE - half_dim));
+				basis_B.push_back((x << (BINWORD_SIZE - dimension)) >> (BINWORD_SIZE - half_dim));
+				if(rank_of_vector_set_cpp(basis) != (Integer)basis.size() || rank_of_vector_set_cpp(basis_B) != (Integer)basis_B.size()) {
+					basis.pop_back();
+					basis_B.pop_back();
+				}
+			}
+		}
+	}
+
+	vector<BinWord>& operator[] (keyType key) {return partition[key];}
+	const vector<BinWord>& operator[](keyType key) const {return partition.at(key);}
+};
+
+
+/*
+ * ===========================================
+ * The PartitionPreservingLinearMappings class
+ * ===========================================
+ * It describes a search strategy for linear bijections which send an input partition to an output one. It is essentially made of :
+ * - two pointers to the input/output partitions.
+ * - the Boolean variable single_non_trivial_answer indicates whether a full search is perfomed or not.
+ * - the Boolean variable diagonal_mappings indicates whether the linear bijections must have the form diag(A, B) or not.
+ * - the integer number_of_threads.
+ * - a vector of solutions found_mappings.
+ *
+ * Some methods are also described:
+ * - recursive_search and diagonal_recursive_search which handles the search. They follow the same DFS strategy.
+ * diagonal_recursive_search only considers mappings of the form diag(A, B).
+ * - recursive_partition_preserving_linear_mappings is the recursive search for partition-preserving linear mappings.
+ */
+template <class keyType>
+class PartitionPreservingLinearMappings {
+private:
+	bool single_non_trivial_answer;
+	bool diagonal_mappings;
+	unsigned int number_of_threads;
+	uint64_t dimension;
+	Partition<keyType> *partition_in;
+	Partition<keyType> *partition_out;
+
+public:
+	vector<vector<BinWord>> found_mappings;
+
+	PartitionPreservingLinearMappings(Partition<keyType> *_partition_in, Partition<keyType> *_partition_out, bool _single_non_trivial_answer, bool _diagonal_mappings, unsigned int _number_of_threads) :
+			single_non_trivial_answer(_single_non_trivial_answer),
+			diagonal_mappings(_diagonal_mappings),
+			number_of_threads(_number_of_threads),
+			partition_in(_partition_in),
+			partition_out(_partition_out) {
+			assert(_partition_in->dim() == _partition_out->dim());
+
+			if(!diagonal_mappings)
+				dimension = _partition_in->dim();
+			else {
+				assert(_partition_in->dim() % 2 == 0);
+				dimension = _partition_in->dim() / 2;
+			}
+		}
+
+	vector<vector<BinWord>> recursive_search(vector<BinWord> basis_out) {
+		unsigned int current_index = basis_out.size();
+		// End condition, return the found solution
+		if(current_index == dimension) {
+			if(single_non_trivial_answer && basis_out == partition_in->basis) // If a single solution is wanted but this one is the identity, returns nothing
+				return {};
+			else { // In any other case, return the LUT
+				vector<BinWord> lut(ONE << dimension);
+				BinWord x, y;
+				for(BinWord i = 0; i < (ONE << dimension); i++) {
+					x = matrix_vector_multiplication(i, partition_in->basis);
+					y = matrix_vector_multiplication(i, basis_out);
+					lut[x] = y;
+				}
+				return {lut};
+			}
+		}
+
+		vector<vector<BinWord>> solutions; // The list of the found solutions
+		BinWord x, y, v, w, image, pre_image, i;
+		bool partition_preserving = true;
+
+		x = partition_in->basis[current_index]; // The preimage of the currently guessed image.
+		const keyType bucket_key = partition_in->in_which_bucket(x); // The bucket to inspect
+		const vector<BinWord> bucket = (*partition_out)[bucket_key];
+
+		for(unsigned int k = 0; k < bucket.size() && !(single_non_trivial_answer && solutions.size()); k++) { // For each possible image
+			y = bucket[k];
+
+			basis_out.push_back(y);
+
+			// Early abort if the dimension does not increase (bijective mappings)
+			if(rank_of_vector_set_cpp(basis_out) == (Integer) (current_index + 1)) {
+
+				// The partition-preserving condition : each image must belong to the out_bucket associated to in_bucket to which the preimage belongs.
+				// The condition is only tested on (preimage, image) pairs that have not been tested before
+				for(i = 0; i < (1 << (current_index)) && partition_preserving; i++) {
+					v = matrix_vector_multiplication(i, partition_in->basis); // The i-th vector of Span(basis_in)
+					w = matrix_vector_multiplication(i, basis_out); // The i-th vector of Span(basis_out)
+					pre_image = x ^ v;
+					image = y ^ w;
+
+					if(partition_out->in_which_bucket(image) != partition_in->in_which_bucket(pre_image))
+						partition_preserving = false;
+				}
+
+				// Recursive call if no contradiction for now
+				if(partition_preserving) {
+					const vector<vector<BinWord>> recursive_solutions = recursive_search(basis_out);
+					solutions.insert(solutions.end(), recursive_solutions.begin(), recursive_solutions.end());  // Adds the found mappings to the list
+				}
+			}
+			basis_out.pop_back();
+			partition_preserving = true;
+		}
+		return solutions;
+	}
+
+	vector<vector<BinWord>> diagonal_recursive_search(vector<BinWord> basis_out_A, vector<BinWord> basis_out_B) {
+		unsigned int current_index = basis_out_A.size();
+
+		// End condition, return the found solution
+		if(current_index == dimension) {
+			if(single_non_trivial_answer && basis_out_A == partition_in->basis && basis_out_B == partition_in->basis_B) // If a single solution is wanted but this one is the identity, returns nothing
+				return {};
+			else { // In any other case, return the LUTs of A and B (the one of B is appended to the one of A).
+				vector<BinWord> luts_AB(ONE << (dimension + 1));
+				BinWord x, y;
+				for(BinWord i = 0; i < (ONE << dimension); i++) {
+					x = matrix_vector_multiplication(i, partition_in->basis);
+					y = matrix_vector_multiplication(i, basis_out_A);
+					luts_AB[x] = y;
+					x = matrix_vector_multiplication(i, partition_in->basis_B);
+					y = matrix_vector_multiplication(i, basis_out_B);
+					luts_AB[(ONE << dimension) + x] = y;
+				}
+				return {luts_AB};
+			}
+		}
+
+		vector<vector<BinWord>> solutions; // The list of the found solutions
+		BinWord x_A, x_B, y_A, y_B, image, pre_image, i, j;
+		bool partition_preserving = true;
+
+		x_A = partition_in->basis[current_index]; // The preimage of the currently guessed image.
+		x_B = partition_in->basis_B[current_index];
+		const keyType bucket_key = partition_in->in_which_bucket((x_B << dimension) | x_A); // The bucket to inspect
+		const vector<BinWord> bucket = (*partition_out)[bucket_key];
+
+		for(unsigned int k = 0; k < bucket.size() && !(single_non_trivial_answer && found_mappings.size()); k++) { // For each possible image
+			y_A = (bucket[k] << (BINWORD_SIZE - dimension)) >> (BINWORD_SIZE - dimension);
+			y_B = (bucket[k] << (BINWORD_SIZE - dimension * 2)) >> (BINWORD_SIZE - dimension);
+
+			basis_out_A.push_back(y_A);
+			basis_out_B.push_back(y_B);
+
+			// Early abort if one of the dimension does not increase
+			if(rank_of_vector_set_cpp(basis_out_A) == (Integer) (current_index + 1) &&
+			   rank_of_vector_set_cpp(basis_out_B) == (Integer) (current_index + 1)) {
+
+				// The partition-preserving condition : each image must belong to the out_bucket associated to in_bucket to which the preimage belongs.
+				// The condition is only tested on (preimage, image) pairs that have not been tested before
+				for(i = 0; i < (1 << (current_index + 1)) && partition_preserving; i++) {
+					x_A = matrix_vector_multiplication(i, partition_in->basis); // The i-th vector of <b for b in basis_in>
+					y_A = matrix_vector_multiplication(i, basis_out_A); // The i-th vector of <b for b in basis_ou_At>
+					for(j = 0; j < (1 << (current_index + 1)) && partition_preserving; j++) {
+						x_B = matrix_vector_multiplication(j, partition_in->basis_B); // The j-th vector of <b for b in basis_B>
+						y_B = matrix_vector_multiplication(j, basis_out_B); // The j-th vector of <b for b in basis_out_B>
+
+						if(i > (1 << current_index) || j > (1 << current_index)) {
+							pre_image = (x_B << dimension) | x_A;
+							image = (y_B << dimension) | y_A;
+							if(partition_out->in_which_bucket(image) != partition_in->in_which_bucket(pre_image))
+								partition_preserving = false;
+						}
+					}
+				}
+
+				// Recursive call if no contradiction for now
+				if(partition_preserving) {
+					const vector<vector<BinWord>> recursive_solutions = diagonal_recursive_search(basis_out_A, basis_out_B);
+					solutions.insert(solutions.end(), recursive_solutions.begin(), recursive_solutions.end());  // Adds the found mappings to the list
+				}
+			}
+			basis_out_A.pop_back();
+			basis_out_B.pop_back();
+			partition_preserving = true;
+		}
+		return solutions;
+	}
+
+	void search() {
+		if(number_of_threads == 1) {
+			if(diagonal_mappings)
+				found_mappings = diagonal_recursive_search({}, {});
+			else
+				found_mappings = recursive_search({});
+		}
+		else {
+			keyType bucket_key;
+			if(diagonal_mappings)
+				bucket_key = partition_in->in_which_bucket((partition_in->basis_B[0] << dimension) | partition_in->basis[0]);
+			else
+				bucket_key = partition_in->in_which_bucket(partition_in->basis[0]);
+			const vector<BinWord> bucket = (*partition_out)[bucket_key];
+
+			bool found = false;
+			vector<vector<vector<BinWord>>> thread_solutions(number_of_threads);
+
+			omp_set_num_threads(number_of_threads);
+		#pragma omp parallel for default(none) shared(bucket, found, thread_solutions, cout)
+			for(unsigned int i = 0; i < bucket.size(); i++) {
+				if(!(single_non_trivial_answer && found)) {
+					vector <vector<BinWord>> cur_solutions;
+					if(diagonal_mappings) {
+						const BinWord y_A = (bucket[i] << (BINWORD_SIZE - dimension)) >> (BINWORD_SIZE - dimension);
+						const BinWord y_B = (bucket[i] << (BINWORD_SIZE - dimension * 2)) >> (BINWORD_SIZE - dimension);
+						cur_solutions = diagonal_recursive_search({y_A}, {y_B});
+					} else
+						cur_solutions = recursive_search({bucket[i]});
+					if(single_non_trivial_answer && cur_solutions.size()) {
+						#pragma omp critical
+						found = true;
+					}
+					thread_solutions[omp_get_thread_num()].insert(thread_solutions[omp_get_thread_num()].end(), cur_solutions.begin(), cur_solutions.end());
+				}
+			}
+
+			for(auto & v : thread_solutions){
+				found_mappings.insert(found_mappings.end(), v.begin(), v.end());
+			}
+		}
+	}
+};
+
+vector<pair<vector<BinWord>, vector<BinWord>>> linear_automorphism_search(const vector<vector<Integer>> &lat,  const bool &single_non_trivial_answer, const bool &alternative_partition, const unsigned int &number_of_threads);
+
+pair<vector<BinWord>, vector<BinWord>> cpp_is_linearly_self_equivalent_from_lat(const vector<vector<Integer>> &lat, const string algo, const unsigned int &number_of_threads);
+vector<pair<vector<BinWord>, vector<BinWord>>> cpp_linear_automorphisms_from_lat(const vector<vector<Integer>> &lat, const string algo, const unsigned int &number_of_threads);
+
+#endif // PARTITION_PRESERVING_LINEAR_MAPPING_HPP

--- a/sboxU/sboxU_cython/sboxu_cpp_utils.cpp
+++ b/sboxU/sboxU_cython/sboxu_cpp_utils.cpp
@@ -1,3 +1,5 @@
+// Modified on 2025-07-23 by baudrin-j.
+
 #include "sboxu_cpp_utils.hpp"
 
 BinWord oplus_cpp(BinWord x, BinWord y)
@@ -27,6 +29,19 @@ std::vector<BinWord> component_cpp(BinWord a, std::vector<BinWord> f)
     for (BinWord x=0; x<f.size(); x++)
         result[x] = scal_prod_cpp(a, f[x]);
     return result;
+}
+
+
+BinWord matrix_vector_multiplication(BinWord vect, const std::vector<BinWord> &matrix) {
+	BinWord eval = 0;
+	unsigned int i = 0;
+	while(vect) {
+		if(vect & ONE)
+			eval ^= matrix[i];
+		vect = vect >> 1;
+		i++;
+	}
+	return eval;
 }
 
 // !SECTION! Generating and studying permutations 

--- a/sboxU/sboxU_cython/sboxu_cpp_utils.hpp
+++ b/sboxU/sboxU_cython/sboxu_cpp_utils.hpp
@@ -29,6 +29,10 @@ BinWord scal_prod_cpp(BinWord x, BinWord y) ;
 /* @return the component $x \mapsto b . f(x)$. */ 
 std::vector<BinWord> component_cpp(BinWord a, std::vector<BinWord> f);
 
+/* @return the product of binary matrix and vector:
+ * M*v if matrix is a list of columns or v*M if matrix is a list of rows. */
+BinWord matrix_vector_multiplication(BinWord vect, const std::vector<BinWord> &matrix);
+
 
 // !SUBSECTION! Generating and testing permutations 
 

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ extra_compile_args = ["-O3", "-march=native", "-std=c++17", "-pthread", "-Wno-na
 extra_link_args=[]
 
 if sys.platform == 'darwin':
-	extra_compile_args += ['-lomp', '-I/usr/local/opt/libomp/include']
-	extra_link_args += ['-lomp', '-L/usr/local/opt/libomp/include']
+    extra_compile_args += ['-lomp', '-I/usr/local/opt/libomp/include'] # ['-Xpreprocessor', '-fopenmp']
+    extra_link_args += ['-lomp', '-L/usr/local/opt/libomp/include'] # ['-lomp']
 else:
 	extra_compile_args += ['-fopenmp']
 	extra_link_args += ['-fopenmp']

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# Modified on 2025-07-07 by baudrin-j.
+
 import os
 import sys
 
@@ -36,7 +38,7 @@ setup(
                 extra_link_args = extra_link_args,
                 extra_compile_args = extra_compile_args,
             )
-                for name in [ "cpp_diff_lin", "cpp_utils", "cpp_equiv", "cpp_equiv_approx", "cpp_ccz" ]
+                for name in [ "cpp_diff_lin", "cpp_utils", "cpp_equiv", "cpp_equiv_approx", "cpp_ccz", "cpp_partition_preserving_linear_mapping"]
         ],
         language_level = "3",
     ),


### PR DESCRIPTION
- Parallelized C++ search of linear automorphisms of a vectorial Boolean function.

- Python/Sage interface through new functions : `linear_automorphisms` (or `linear_automorphisms_from_lat`) for the full group and `is_linearly_self_equivalent` (or `is_linearly_self_equivalent_from_lat`) for a single non-trivial automorphism (if it exists).

- Some tests to compare the new functions with the already-exisiting `table_linear_automorphisms` function.