### PR TITLE
fix: replace int literals with typed casts to prevent integer overflo…

### DIFF
--- a/sboxU/cpp/algorithms/binLinearBasis.cpp
+++ b/sboxU/cpp/algorithms/binLinearBasis.cpp
@@ -47,7 +47,7 @@ std::vector<BinWord> cpp_BinLinearBasis::get_basis() const
 
 std::vector<BinWord> cpp_BinLinearBasis::span() const
 {
-    unsigned int total_size = 1 << basis.size();
+    BinWord total_size = (BinWord)1 << basis.size();
     std::vector<BinWord>
         result(total_size, 0),
         vects = get_basis();

--- a/sboxU/cpp/core/prng.hpp
+++ b/sboxU/cpp/core/prng.hpp
@@ -61,7 +61,7 @@ public:
             if (cpp_hamming_weight(range) > 1)
             {
                 BinWord
-                    mask = (1 << (cpp_msb(range) + 2)) - 1,
+                    mask = ((BinWord)1 << (cpp_msb(range) + 2)) - 1,
                     result = range+1;
                 while (result >= range)
                     result = gen() & mask;

--- a/sboxU/cpp/core/s_box.hpp
+++ b/sboxU/cpp/core/s_box.hpp
@@ -92,17 +92,17 @@ public:
 
     inline Integer input_space_size() const
     {
-        return (1 << input_length);
+        return (Integer)1 << input_length;
     };
 
     inline Integer get_output_length() const
     {
         return output_length;
     };
-    
+
     Integer output_space_size() const
     {
-        return (1 << output_length);
+        return (Integer)1 << output_length;
     };
     
 

--- a/sboxU/cpp/statistics/boomerang.cpp
+++ b/sboxU/cpp/statistics/boomerang.cpp
@@ -109,7 +109,7 @@ std::vector< std::vector<Integer>> cpp_fbct(
     {
         result[a][0] = s.input_space_size();
         result[a][a] = s.input_space_size();
-        for(BinWord x = 0, _max = s.input_space_size(), _msb = 1 << cpp_msb(a) ; x < _max; x+=_msb)
+        for(BinWord x = 0, _max = s.input_space_size(), _msb = (BinWord)1 << cpp_msb(a) ; x < _max; x+=_msb)
         {
             std::vector<std::vector<BinWord> > xor_list(s.output_space_size(), std::vector<BinWord>(0));
             for(BinWord _ceil = x + _msb; x < _ceil; x++)

--- a/sboxU/cpp/statistics/linear.cpp
+++ b/sboxU/cpp/statistics/linear.cpp
@@ -84,9 +84,9 @@ cpp_Spectrum cpp_absolute_walsh_spectrum(
 cpp_S_box cpp_invert_lat(const std::vector< std::vector<Integer> > & l)
 {
     std::vector<BinWord> result(l.size(), 0);
-    for (unsigned int i=0; l[0].size() > (1 << i); i++)
+    for (unsigned int i=0; l[0].size() > ((BinWord)1 << i); i++)
     {
-        Integer b = (1 << i), sum;
+        Integer b = (Integer)1 << i, sum;
         for (unsigned int x=0; x<l.size(); x++)
         {
             sum = 0;


### PR DESCRIPTION
…w UB

Shifts of the form `1 << n` use a 32-bit int literal, causing signed overflow UB when n >= 31. Affected sites:
- s_box.hpp: input_space_size() and output_space_size()
- prng.hpp: rejection-sampling mask in operator()(begin, end)
- linear.cpp: loop bound and coordinate index in cpp_invert_lat
- binLinearBasis.cpp: total_size in span()
- boomerang.cpp: _msb in cpp_fbct inner loop